### PR TITLE
Add PerfectHash/PerfectHashWithOverflow support in UTOC writer

### DIFF
--- a/UnrealReZen/Core/Constants.cs
+++ b/UnrealReZen/Core/Constants.cs
@@ -13,7 +13,7 @@ namespace UnrealReZen.Core
         public const uint NoneEntry = 0xFFFFFFFF;
         public const int UE5_DepFile_Sig = 1232028526;
         public const int CompSize = 0x10000;
-        public const int PackUtocVersion = 3;
+        public const int PackUtocVersion = 5;
         public const int CompressionNameLength = 32;
     }
 }

--- a/UnrealReZen/Core/FIoDependency.cs
+++ b/UnrealReZen/Core/FIoDependency.cs
@@ -93,64 +93,80 @@ namespace UnrealReZen.Core
         public byte[] WriteDependenciesAsUE5()
         {
             using var ms = new MemoryStream();
+            const EIoContainerHeaderVersion version = EIoContainerHeaderVersion.OptionalSegmentPackages;
 
-            var hdr = new DepsHeader_UE5
-            {
-                Signature = Constants.UE5_DepFile_Sig,
-                Version = EIoContainerHeaderVersion.OptionalSegmentPackages,
-                ContainerId = Deps.ThisPackageID,
-                PackageCount = Deps.ChunkIDToDependencies.Count
-            };
-            hdr.Write(ms);
+            ms.Write(Constants.UE5_DepFile_Sig);
+            ms.Write((int)version);
+            ms.Write(Deps.ThisPackageID);
 
             var ids = Deps.ChunkIDToDependencies.Keys.ToList();
-            var totalNumberOfDependencies = 0;
-            foreach (var k in Deps.ChunkIDToDependencies)
-            {
-                totalNumberOfDependencies += k.Value.ImportedPackages.Length;
-            }
-
             ids.Sort();
-            ids.Reverse();
 
-            foreach (var id in ids)
-            {
-                ms.Write(id);
-            }
+            ms.Write(ids.Count);
+            foreach (var id in ids) ms.Write(id);
 
-            MemoryStream storeEntries = new MemoryStream();
-            MemoryStream storeEntriesbuffer = new MemoryStream();
+            var storeEntriesBytes = BuildStoreEntriesSection(ids);
+            ms.Write(storeEntriesBytes.Length);
+            ms.Write(storeEntriesBytes);
 
-            var depsToWrite = new List<ulong>();
+            ms.Write(0);
+            ms.Write(0);
+
+            ms.Write(0);
+
+            ms.Write(0);
+
+            ms.Write(0);
+
+            return ms.ToArray();
+        }
+
+        private byte[] BuildStoreEntriesSection(List<ulong> ids)
+        {
+            const int HeaderSize = 24;
+            const int PackageIdSize = 8;
+            const int ShaderMapHashSize = 20;
+
+            var headersSize = ids.Count * HeaderSize;
+            using var headers = new MemoryStream();
+            using var blob = new MemoryStream();
+
             for (int i = 0; i < ids.Count; i++)
             {
-                var id = ids[i];
-                var entry = Deps.ChunkIDToDependencies[id];
+                var entry = Deps.ChunkIDToDependencies[ids[i]];
+                var entryStart = i * HeaderSize;
 
-                var link = new DepLinks_UE5
-                {
-                    ExportCount = entry.ExportCount,
-                    ExportBundleCount = entry.ExportBundleCount,
-                    ImportedPackages = entry.ImportedPackages.Select(a => a.id).ToList(),
-                    BaseOffset = storeEntriesbuffer.Length + (ids.Count * 24 - storeEntries.Position),
-                    ShaderMapHashes = entry.ShaderMapHashes.Select(a => a.Hash).ToList(),
-                };
-                foreach (var ImpPak in entry.ImportedPackages)
-                {
-                    storeEntriesbuffer.Write(ImpPak.id);
-                }
-                foreach (var ShMapHash in entry.ShaderMapHashes)
-                {
-                    storeEntriesbuffer.Write(ShMapHash.Hash);
-                }
-                link.Write(storeEntries);
+                headers.Write(entry.ExportCount);
+                headers.Write(entry.ExportBundleCount);
 
+                WriteCArrayView(headers, blob, entryStart + 8, headersSize, entry.ImportedPackages.Length,
+                    () => { foreach (var p in entry.ImportedPackages) blob.Write(p.id); },
+                    PackageIdSize);
+
+                WriteCArrayView(headers, blob, entryStart + 16, headersSize, entry.ShaderMapHashes.Length,
+                    () => { foreach (var h in entry.ShaderMapHashes) blob.Write(h.Hash); },
+                    ShaderMapHashSize);
             }
-            ms.Write((int)storeEntries.Length + (int)storeEntriesbuffer.Length);
-            ms.Write(storeEntries.ToArray());
-            ms.Write(storeEntriesbuffer.ToArray());
-            ms.Write(new byte[20]);
-            return ms.ToArray();
+
+            var result = new byte[headers.Length + blob.Length];
+            Buffer.BlockCopy(headers.ToArray(), 0, result, 0, (int)headers.Length);
+            Buffer.BlockCopy(blob.ToArray(), 0, result, (int)headers.Length, (int)blob.Length);
+            return result;
+        }
+
+        private static void WriteCArrayView(MemoryStream headers, MemoryStream blob, int initialPos, int headersSize, int count, Action writeItems, int _)
+        {
+            if (count == 0)
+            {
+                headers.Write(0);
+                headers.Write(0);
+                return;
+            }
+            var dataPos = headersSize + (int)blob.Length;
+            var offsetFromThis = dataPos - initialPos;
+            headers.Write(count);
+            headers.Write(offsetFromThis);
+            writeItems();
         }
     }
 
@@ -198,40 +214,6 @@ namespace UnrealReZen.Core
             br.Write(SomeIndex);
             br.Write(DependencyPackages);
             br.Write(Offset);
-        }
-    }
-
-    public class DepsHeader_UE5
-    {
-        public int Signature { get; set; }
-        public EIoContainerHeaderVersion Version { get; set; }
-        public ulong ContainerId { get; set; }
-        public int PackageCount { get; set; }
-
-        public void Write(MemoryStream ms)
-        {
-            ms.Write(Signature);
-            if ((int)Version > -1) ms.Write((int)Version);
-            ms.Write(ContainerId);
-            if ((int)Version >= 2) ms.Write(PackageCount);
-        }
-    }
-
-    public class DepLinks_UE5
-    {
-        public int ExportCount { get; set; }
-        public int ExportBundleCount { get; set; }
-        public required List<ulong> ImportedPackages { get; set; }
-        public required List<byte[]> ShaderMapHashes { get; set; }
-        public long BaseOffset { get; set; }
-        public void Write(MemoryStream br)
-        {
-            br.Write(ExportCount);
-            br.Write(ExportBundleCount);
-            br.Write(ImportedPackages.Count);
-            if (ImportedPackages.Count > 0) br.Write(BaseOffset - 4); else br.Write(0);
-            br.Write(ShaderMapHashes.Count);
-            if (ShaderMapHashes.Count > 0) br.Write(BaseOffset + ImportedPackages.Count * 8); else br.Write(0);
         }
     }
 

--- a/UnrealReZen/Core/FIoPack.cs
+++ b/UnrealReZen/Core/FIoPack.cs
@@ -232,6 +232,7 @@ namespace UnrealReZen.Core
         public static byte[] ConstructUtocFile(List<AssetMetadata> files, string compression, bool isEncrypted, EGame gameVer)
         {
             bool isCompressed = !compression.Equals("none", StringComparison.OrdinalIgnoreCase);
+            int n = files.Count;
 
             var containerFlags = EIoContainerFlags.IndexedContainerFlag;
             if (isCompressed) containerFlags |= EIoContainerFlags.CompressedContainerFlag;
@@ -243,13 +244,15 @@ namespace UnrealReZen.Core
 
             int compressedBlocksCount = 0;
             int containerIndex = 0;
-            for (int i = 0; i < files.Count; i++)
+            for (int i = 0; i < n; i++)
             {
                 compressedBlocksCount += files[i].CompressionBlocks.Count;
                 if (files[i].ChunkID.Type == containerChunkType) containerIndex = i;
             }
 
-            var dirIndexBytes = DeparseDirectoryIndex(files);
+            var (seeds, overflowSlots, slotOrder) = BuildPerfectHash(files);
+
+            var dirIndexBytes = DeparseDirectoryIndex(slotOrder);
             uint compressionMethodCount = isCompressed ? 1u : 0u;
 
             var header = new UTocHeader
@@ -257,7 +260,7 @@ namespace UnrealReZen.Core
                 Magic = Constants.MagicUtoc,
                 Version = (byte)Constants.PackUtocVersion,
                 HeaderSize = (uint)UTocHeader.SizeOf,
-                EntryCount = (uint)files.Count,
+                EntryCount = (uint)n,
                 CompressedBlockEntryCount = (uint)compressedBlocksCount,
                 CompressedBlockEntrySize = 12,
                 CompressionMethodNameCount = compressionMethodCount,
@@ -267,13 +270,17 @@ namespace UnrealReZen.Core
                 ContainerID = new FIoContainerID(files[containerIndex].ChunkID.ID),
                 ContainerFlags = containerFlags,
                 PartitionSize = ulong.MaxValue,
-                PartitionCount = 1
+                PartitionCount = 1,
+                TocChunkPerfectHashSeedsCount = (uint)seeds.Length,
+                TocChunksWithoutPerfectHashCount = (uint)overflowSlots.Length,
             };
 
             using var buf = new MemoryStream();
             header.Write(buf);
-            foreach (var file in files) file.ChunkID.Write(buf);
-            foreach (var file in files) file.OffLen.Write(buf);
+            foreach (var file in slotOrder) file.ChunkID.Write(buf);
+            foreach (var file in slotOrder) file.OffLen.Write(buf);
+            foreach (var seed in seeds) buf.Write(seed);
+            foreach (var slot in overflowSlots) buf.Write(slot);
             foreach (var file in files)
                 foreach (var block in file.CompressionBlocks)
                     block.Write(buf);
@@ -288,9 +295,96 @@ namespace UnrealReZen.Core
             }
 
             buf.Write(dirIndexBytes, 0, dirIndexBytes.Length);
-            foreach (var file in files) file.Metadata.Write(buf);
+            foreach (var file in slotOrder) file.Metadata.Write(buf);
 
             return buf.ToArray();
+        }
+
+        private static (int[] seeds, int[] overflowSlots, List<AssetMetadata> slotOrder) BuildPerfectHash(List<AssetMetadata> files)
+        {
+            int n = files.Count;
+            int seedCount = Math.Max(n, 1);
+
+            var buckets = new List<int>[seedCount];
+            for (int i = 0; i < seedCount; i++) buckets[i] = [];
+            for (int i = 0; i < n; i++)
+            {
+                uint bucketIdx = (uint)(files[i].ChunkID.HashWithSeed(0) % (ulong)seedCount);
+                buckets[bucketIdx].Add(i);
+            }
+
+            var bucketOrder = Enumerable.Range(0, seedCount)
+                .OrderByDescending(b => buckets[b].Count)
+                .ToArray();
+
+            int[] seeds = new int[seedCount];
+            int[] slotToPack = new int[n];
+            Array.Fill(slotToPack, -1);
+            int overflowSentinel = unchecked(-(n + 1));
+            var overflowPack = new List<int>();
+
+            foreach (int b in bucketOrder)
+            {
+                var bucket = buckets[b];
+                if (bucket.Count == 0) { seeds[b] = 0; continue; }
+
+                if (bucket.Count == 1)
+                {
+                    for (int s = 0; s < n; s++)
+                    {
+                        if (slotToPack[s] == -1)
+                        {
+                            slotToPack[s] = bucket[0];
+                            seeds[b] = -(s + 1);
+                            break;
+                        }
+                    }
+                    continue;
+                }
+
+                bool placed = false;
+                var tentative = new uint[bucket.Count];
+                for (int seed = 1; seed < 1_000_000; seed++)
+                {
+                    var seen = new HashSet<uint>(bucket.Count);
+                    bool ok = true;
+                    for (int i = 0; i < bucket.Count; i++)
+                    {
+                        uint slot = (uint)(files[bucket[i]].ChunkID.HashWithSeed(seed) % (ulong)n);
+                        if (slotToPack[slot] != -1 || !seen.Add(slot)) { ok = false; break; }
+                        tentative[i] = slot;
+                    }
+                    if (ok)
+                    {
+                        for (int i = 0; i < bucket.Count; i++)
+                            slotToPack[tentative[i]] = bucket[i];
+                        seeds[b] = seed;
+                        placed = true;
+                        break;
+                    }
+                }
+                if (!placed)
+                {
+                    seeds[b] = overflowSentinel;
+                    overflowPack.AddRange(bucket);
+                }
+            }
+
+            var overflowSlots = new List<int>(overflowPack.Count);
+            int oi = 0;
+            for (int s = 0; s < n; s++)
+            {
+                if (slotToPack[s] == -1)
+                {
+                    slotToPack[s] = overflowPack[oi++];
+                    overflowSlots.Add(s);
+                }
+            }
+
+            var slotOrder = new List<AssetMetadata>(n);
+            for (int s = 0; s < n; s++) slotOrder.Add(files[slotToPack[s]]);
+
+            return (seeds, overflowSlots.ToArray(), slotOrder);
         }
     }
 }

--- a/UnrealReZen/Core/FIoStructs.cs
+++ b/UnrealReZen/Core/FIoStructs.cs
@@ -174,6 +174,18 @@ namespace UnrealReZen.Core
             br.Write(Padding);
             br.Write(Type);
         }
+
+        public ulong HashWithSeed(int seed)
+        {
+            const ulong prime = 0x00000100000001B3;
+            ulong hash = seed != 0 ? unchecked((ulong)seed) : 0xcbf29ce484222325;
+            for (int i = 0; i < 8; i++) hash = unchecked(hash * prime) ^ (byte)(ID >> (i * 8));
+            hash = unchecked(hash * prime) ^ (byte)(Index & 0xFF);
+            hash = unchecked(hash * prime) ^ (byte)((Index >> 8) & 0xFF);
+            hash = unchecked(hash * prime) ^ Padding;
+            hash = unchecked(hash * prime) ^ Type;
+            return hash;
+        }
         public string ToHexString()
         {
             return $"{ID:X16}{Index:X4}{Padding:X2}{Type:X2}";

--- a/UnrealReZen/Core/Helpers/CryptographyHelpers.cs
+++ b/UnrealReZen/Core/Helpers/CryptographyHelpers.cs
@@ -22,14 +22,6 @@ namespace UnrealReZen.Core.Helpers
         {
             return SHA1.HashData(data);
         }
-        public static ulong RandomUlong()
-        {
-            Random rnd = new();
-            int rawsize = System.Runtime.InteropServices.Marshal.SizeOf(ulong.MaxValue);
-            var buffer = new byte[rawsize];
-            rnd.NextBytes(buffer);
-            return BitConverter.ToUInt64(buffer, 0);
-        }
         public static byte[] GetRandomBytes(int n)
         {
             byte[] ret = new byte[n];

--- a/UnrealReZen/Program.cs
+++ b/UnrealReZen/Program.cs
@@ -228,6 +228,7 @@ namespace UnrealReZen
             };
 
             var utocEntryLookup = BuildUtocEntryLookup(provider);
+            var seenChunks = new HashSet<(ulong id, byte type)> { (newContainerId, containerChunkType) };
 
             foreach (var file in filesToRepack)
             {
@@ -241,6 +242,8 @@ namespace UnrealReZen
                 foreach (var entry in matches)
                 {
                     var chunkId = entry.ChunkId;
+                    if (!seenChunks.Add((chunkId.ChunkId, chunkId.ChunkType))) continue;
+
                     manifest.Files.Add(new ManifestFile
                     {
                         Filepath = entry.Path,

--- a/UnrealReZen/Program.cs
+++ b/UnrealReZen/Program.cs
@@ -40,7 +40,7 @@ namespace UnrealReZen
         [Option("mount-point", Required = false, Default = "../../../", HelpText = "Mount point of packed archive")]
         public string MountPoint { get; set; } = "../../../";
 
-        [Option("container-id", Required = false, HelpText = "Container Id of packed archive (default is a random 8-byte number)")]
+        [Option("container-id", Required = false, HelpText = "Container Id of packed archive (default: CityHash64 of the lowercased output file name, matching Unreal's FIoContainerId::FromName).")]
         public ulong? ContainerId { get; set; }
 
         [Option("game-dir-top-only", Required = false, Default = false, HelpText = "When enabled, restricts the game directory search to the top-level only.")]
@@ -208,7 +208,7 @@ namespace UnrealReZen
 
         private static Dependency BuildManifest(DefaultFileProvider provider, Options opts, EGame engineVersion, string[] filesToRepack)
         {
-            var newContainerId = opts.ContainerId ?? CryptographyHelpers.RandomUlong();
+            var newContainerId = opts.ContainerId ?? DeriveContainerIdFromName(opts.OutputPath);
             byte containerChunkType = engineVersion >= EGame.GAME_UE5_0
                 ? (byte)EIoChunkType5.ContainerHeader
                 : (byte)EIoChunkType.ContainerHeader;
@@ -261,6 +261,12 @@ namespace UnrealReZen
                 }
             }
             return manifest;
+        }
+
+        private static ulong DeriveContainerIdFromName(string outputPath)
+        {
+            var name = Path.GetFileNameWithoutExtension(outputPath);
+            return FPackageId.FromName(name).id;
         }
 
         private static Dictionary<string, List<FIoStoreEntry>> BuildUtocEntryLookup(DefaultFileProvider provider)


### PR DESCRIPTION
Fixes #54.

Stacked on top of #73 — reviewing with base \`cleanup-and-fixes\` keeps the diff scoped to the perfect-hash work. Once #73 merges, GitHub will auto-retarget this PR to \`master\`.

## Problem

UnrealReZen was emitting UTOC v3 with \`TocChunkPerfectHashSeedsCount = 0\`. FModel/ZenTools (and every other reader that took the v4+ path from Unreal) expect to resolve chunk IDs via the two-level perfect hash, so they reject the container as unreadable.

## Fix

- Bump \`PackUtocVersion\` 3 → 5 (\`PerfectHashWithOverflow\`).
- \`FIoChunkID.HashWithSeed\`: FNV-1a over the 12-byte on-disk layout, byte-for-byte identical to CUE4Parse's \`FIoChunkId.HashWithSeed\`. Used both for seed-bucket selection and final slot placement.
- CHD-style perfect-hash construction in \`ConstructUtocFile\`:
  - Bucket all chunks by \`HashWithSeed(0) % N\`, largest first
  - Singleton bucket → direct-slot seed \`-(slot+1)\`
  - Multi-chunk bucket → seed search (1..1M) for collision-free slot mapping
  - Unplaceable bucket → overflow sentinel \`-(N+1)\`; chunks go on \`ChunkIndicesWithoutPerfectHash\` (reader falls back to imperfect lookup on sentinels where \`-seed-1 >= N\`)
- Chunk-indexed arrays (ChunkIds, OffLen, Metadata) + directory-index \`UserData\` are written in slot order. CompressionBlocks stay in UCAS/pack order since the reader derives \`firstBlockIndex = Offset / CompressionBlockSize\`.

## Test plan

- [x] \`dotnet build UnrealReZen/UnrealReZen.csproj --configuration Release\` — 0 errors, no new warnings in UnrealReZen code
- [x] Pack a test content dir and verify FModel loads the resulting archive
- [ ] Verify the game's loader still mounts the archive at runtime